### PR TITLE
Fixed language name (Python -> Rust) in /rust/

### DIFF
--- a/sheets/rust
+++ b/sheets/rust
@@ -2,6 +2,6 @@
 
 # See also:
 #   rustc
-#   Python language cheat sheets at /rust/
+#   Rust language cheat sheets at /rust/
 #   list of pages:      /rust/:list
 #   search in pages:    /rust/~keyword


### PR DESCRIPTION
Probably a copy-past error.