### PR TITLE
Add reflog, add moving most recent commit

### DIFF
--- a/sheets/git
+++ b/sheets/git
@@ -174,3 +174,15 @@ git diff-tree --no-commit-id --name-only -r ${commit_id}
 
 # list files changed in ${commit_id}, porcelain way, meant to be user facing
 git show --pretty="" --name-only bd61ad98
+
+# See everything you have done, across branches, in a glance,
+# then go to the place right before you broke everything
+git reflog
+git reset HEAD@{hash}
+
+# To move your most recent commit from one branch and stage it on TARGET branch
+git reset HEAD~ --soft
+git stash
+git checkout TARGET
+git stash pop
+git add .


### PR DESCRIPTION
Reflog is a great way to quickly find a place you want to go back in time to. Also, sometimes you accidentally committed something to one branch and you want to move it to another branch, but in your panic forget how to move it over. These two concepts can be very useful when combined, and it nice to have a cht.sh reminder of how to accomplish the task.