### PR TITLE
Fix nmap parameter for scanning specific port

### DIFF
--- a/sheets/nmap
+++ b/sheets/nmap
@@ -17,7 +17,7 @@ nmap -oN [output.txt] [target]
 nmap -oX [output.xml] [target]
 
 # Scan a specific port:
-nmap -source-port [port] [target]
+nmap -p [port] [target]
 
 # Do an aggressive scan:
 nmap -A [target]


### PR DESCRIPTION
According to nmap documentation:

`-p <port ranges>`: Only scan specified ports
`-g/--source-port <portnum>`: Use given port number