### PR TITLE
awk: how to display only first column of text with

### DIFF
--- a/sheets/awk
+++ b/sheets/awk
@@ -12,3 +12,6 @@ printf '1 2 3' | awk 'BEGIN {OFS=":"}; {print $1,$2,$3}'
 
 # search for a paragraph containing string
 awk -v RS='' '/42B/' file
+
+# display only first column from multi-column text
+echo "first-column  second-column  third-column" | awk '{print $1}'


### PR DESCRIPTION
It might be useful e.g. when removing docker containers:
docker ps -a | grep openeir | awk '{print $1 }' | xargs docker rm