### PR TITLE
Fix Merge two dicts

### DIFF
--- a/sheets/_python/1line
+++ b/sheets/_python/1line
@@ -9,7 +9,7 @@ a, b = b, a
 print(list(itertools.chain(*my_list)))
 
 # Merge two dicts
-[**d1, **d2]
+{**d1, **d2}
 
 # Reverse key, value in a dict
 {v: k for k, v in d.items()}


### PR DESCRIPTION
The square brackets are wrong and will generates a `SyntaxError`, the correct way is to use curly brackets. I have tested this before making the update.