### PR TITLE
Fixed flag

### DIFF
--- a/sheets/lvextend
+++ b/sheets/lvextend
@@ -15,7 +15,7 @@ lvextend -L +1G /dev/vg0/mylv
 # Extend volume in volume mylv in groug vg0
 # (defined by volume path /dev/vg0/mylv)
 # to use all of the unallocated space in the volume group vg0:
-lvextend -L +100%FREE /dev/vg0/mylv
+lvextend -l +100%FREE /dev/vg0/mylv
 
 # Extend ext4 filesystem after changing a logical volume
 # (takes volume path as parameter):


### PR DESCRIPTION
Tested it with
  LVM version:     2.02.187(2) (2020-03-24)
  Library version: 1.02.170 (2020-03-24)
  Driver version:  4.42.0

The correct parameter is -l and not -L in the case of a percentage augment