### PR TITLE
Add tests/max-length

### DIFF
--- a/tests/max-length
+++ b/tests/max-length
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Check comment lines (lines starting with #) in cheat sheets
+# and list files with such lines, and return exit code 1.
+# Return exit code 0, if no cheat sheets with long lines found
+
+MAX_STRING_LENGTH=80
+
+MY_DIR=$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")
+SHEETS_DIR="$MY_DIR/sheets"
+
+long_lines_sheets=$(
+  cd "$SHEETS_DIR" &&
+  grep -rPl "#.{${MAX_STRING_LENGTH}}"
+)
+
+if [[ $(printf "%s\n" "$long_lines_sheets" | wc -l) -gt 1 ]]; then
+  echo "Files with long (> 80) lines:"
+  echo
+  printf "%s\n" "$long_lines_sheets"
+  exit 1
+fi
+


### PR DESCRIPTION
Add `tests/max-length` testing length of cheat sheets comment lines.
Can be used interactively:

```
    $ tests/max-length
```