### PR TITLE
Two New Sheets (systemctl & ubuchk)

### DIFF
--- a/sheets/systemctl
+++ b/sheets/systemctl
@@ -1,0 +1,40 @@
+# systemctl
+# Control the systemd system and service manager
+
+# Show only a given value from one of the `show` keys. In this example, the
+# value for the `ActiveState` key for the UFW service will be shown, and only
+# it; ideal for scripting.
+#
+# Using the `--value` flag causes only the value to be displayed.
+systemctl show -p ActiveState --value ufw
+
+# Start, stop, or restart a given service(s).
+systemctl [start|stop|restart] [SERVICE]
+
+# Check if a given service(s) is active. If it is, 'active' will display. An
+# exit status of 0 will be given if it's active, and non-zero otherwise. Use
+# the `-q` or `--quiet` flag to rely only on the exit status.
+systemctl is-active ufw
+
+# Check if a given service(s) has failed. If it is, 'failed' will display. An
+# exit status of 0 will be given if it has failed, and non-zero otherwise. Use
+# the `-q` or `--quiet` flag to rely only on the exit status.
+systemctl is-active ufw
+
+# Check if a given service(s) is enabled. If it is, 'enabled' will display. An
+# exit status of 0 will be given if it's enabled, and non-zero otherwise. Use
+# the `-q` or `--quiet` flag to rely only on the exit status.
+systemctl is-enabled ufw
+
+# List all failed services.
+systemctl --failed
+
+# Shut the system down. Use `suspend` to suspend, `halt` to halt, and `reboot`
+# to instead of reboot the machine.
+systemctl poweroff
+
+# Enable or disable a given service(s).
+systemctl [enable|disable] [SERVICE]
+
+# Show the current status of a given service(s).
+systemctl status [SERVICE]

--- a/sheets/ubuchk
+++ b/sheets/ubuchk
@@ -1,0 +1,27 @@
+# ubuchk
+# Send your Ubuntu system to the doctor for a check-up.
+
+# Force a complete reset of the current user's ubuchk(8) configurations.
+ubuchk --force-reset
+
+# Force ubuchk(8) to run, ignoring Linux distribution type.
+ubuchk --force-run
+
+# List all of the available ubuchk(8) configuration keys.
+--list-keys
+
+# Run UbuChk verbosely, but also omit all messages informing the user that a
+# given key (functionality associated therewith) will be ignored.
+ubuchk -V --hush-ignored
+
+# Query a given alert ID; they are 4-characters in length.
+ubuchk -Q [ID]
+
+# Override a key's value, even if it's set in the user's configuration file.
+# Multiple key=value pairs are allowed, but must be as a comma-separated list.
+ubuchk -k KernParams=false
+
+# Skip a given alert. Multiples allowed, provided they're comma-separated.
+# There is a configuration key for this, but this flag can be useful for
+# one-time uses or for testing.
+ubuchk --skip=[ID]


### PR DESCRIPTION
I realise there's a sheet for `systemctl` VS `service`, but I feel like it would be less confusing for users to have one of each, or at least in addition to.