### PR TITLE
Add cheat sheets for LVM related commands

### DIFF
--- a/sheets/lvchange
+++ b/sheets/lvchange
@@ -1,0 +1,29 @@
+# lvchange
+# Change attributes of a logical volume.
+
+# Change the logical volume to be writeable
+lvchange -ay /dev/vg_name/lv_name
+
+# Disable the logical volume
+lvchange -an /dev/vg_name/lv_name
+
+# Activate a logical volume with synchronization
+lvchange --syncaction none /dev/vg_name/lv_name
+
+# Change a logical volume to be read-only
+lvchange -pr /dev/vg_name/lv_name
+
+# Enable monitoring of the logical volume
+lvchange --monitor y /dev/vg_name/lv_name
+
+# Disable monitoring of the logical volume
+lvchange --monitor n /dev/vg_name/lv_name
+
+# Resizing a volume when snapshotting
+lvchange --refresh /dev/vg_name/lv_name
+
+# Change minor number of a logical volume
+lvchange --minor 42 /dev/vg_name/lv_name
+
+# Change logical volume permission to read-write
+lvchange -ay -M rw /dev/vg_name/lv_name

--- a/sheets/lvconvert
+++ b/sheets/lvconvert
@@ -1,0 +1,32 @@
+# lvconvert
+# Convert a logical volume from linear to mirror or RAID.
+
+# Convert a linear logical volume to a mirrored volume
+lvconvert --type mirror --mirrors <number_of_mirrors> <vg_name>/<lv_name>
+
+# Convert a linear logical volume to a RAID 1 volume
+lvconvert --type raid1 --mirrors 1 <vg_name>/<lv_name>
+
+# Convert a linear logical volume to a RAID 5 volume
+lvconvert --type raid5 <vg_name>/<lv_name>
+
+# Convert a linear logical volume to a RAID 6 volume
+lvconvert --type raid6 <vg_name>/<lv_name>
+
+# Convert a RAID or mirrored logical volume back to linear
+lvconvert --type linear <vg_name>/<lv_name>
+
+# Convert a logical volume and specify the number of parallel operations to use
+lvconvert --type mirror --mirrors <number_of_mirrors> --parallel <max_parallel_operations> <vg_name>/<lv_name>
+
+# Convert a logical volume to a mirror and allocate space from specific physical volumes
+lvconvert --type mirror --mirrors <number_of_mirrors> --alloc anywhere <vg_name>/<lv_name> <physical_volume_path>
+
+# Remove mirroring and reduce it back to a linear volume
+lvconvert --type linear <vg_name>/<lv_name>
+
+# Convert a volume to RAID with specific metadata type
+lvconvert --type raid1 --raidmetadataver 1.2 <vg_name>/<lv_name>
+
+# Convert a volume to a mirror with an additional log device
+lvconvert --type mirror --mirrors <number_of_mirrors> --mirrorlog disk <vg_name>/<lv_name>

--- a/sheets/lvcreate
+++ b/sheets/lvcreate
@@ -1,30 +1,38 @@
 # lvcreate
+# Create a new logical volume.
 
-# Creates a logical volume in an existing volume group.
-# A volume group is a collection of logical and physical volumes.
+# Create a logical volume with a specified size
+lvcreate -L 10G -n my_lv my_vg
 
-# Create a logical volume of 10 gigabytes in the volume group vg1:
-lvcreate -L 10G vg1
+# Create a logical volume with a percentage of the total size of the volume group
+lvcreate -l 50%VG -n my_lv my_vg
 
-# Create a 1500 megabyte linear logical volume named mylv
-# in the volume group vg1:
-lvcreate -L 1500 -n mylv vg1
+# Create a mirror logical volume with 2 copies
+lvcreate -m 1 -L 10G -n my_mirror_lv my_vg
 
-# Create a logical volume called mylv that uses 60% of the total space
-# in the volume group vg1:
-lvcreate -l 60%VG -n mylv vg1
+# Create a thin logical volume from a thin pool
+lvcreate -V 10G -T my_vg/my_pool -n my_thin_lv
 
-# Create a logical volume called mylv that uses all of the unallocated space
-# in the volume group vg1:
-lvcreate -l 100%FREE -n mylv vg1
+# Create a snapshot of an existing logical volume
+lvcreate -L 5G -s -n my_snapshot /dev/my_vg/my_lv
 
-# Create a snapshot (lvsnap) from a logical volume (/dev/vgA/lv1);
-# snapshot size = 10G (total size of the changes)
-lvcreate -L 10G -s -n lvsnap /dev/vgA/lv1
+# Create a striped logical volume
+lvcreate -i 2 -L 10G -n my_striped_lv my_vg
+
+# Create a logical volume with specific physical volumes
+lvcreate -L 10G -n my_pv_lv my_vg /dev/sda1 /dev/sdb1
+
+# Create a logical volume with a specific permission
+lvcreate -L 10G -n my_lv -p rw my_vg
+
+# Create a logical volume while specifying metadata size
+lvcreate --size 10G --name my_lv --poolmetadatasize 128M my_vg
+
+# Create a logical volume with zeroing of the first block
+lvcreate -Z y -L 10G -n my_lv my_vg
 
 # Clone LVM volume: test => testCopy
 lvconvert --type mirror --alloc anywhere -m1 /dev/mylv/test
 lvs -a -o +devices | grep -E "LV|test"
 # After Cpy%Sync is 100% finished:
 lvconvert --splitmirrors 1 --name testCopy /dev/rootvg/test
-

--- a/sheets/lvdisplay
+++ b/sheets/lvdisplay
@@ -1,0 +1,25 @@
+# lvdisplay
+# Display information about logical volumes.
+
+# Display information about all logical volumes
+lvdisplay
+
+# Display information about a specific logical volume
+lvdisplay /dev/<volume_group>/<logical_volume_name>
+
+# Display information with more detailed output
+lvdisplay -v
+
+# Display information with the size displayed in human-readable format
+lvdisplay -C --units=h
+
+# Display information in a format that is easier to parse programmatically
+lvdisplay --reportformat json
+
+# Display information about logical volumes that are currently active
+lvdisplay --active
+
+# Display only specific fields in the output
+lvdisplay -o lv_name,lv_size
+
+Remember to replace placeholders (like `<volume_group>` and `<logical_volume_name>`) with your actual logical volume group and logical volume names.

--- a/sheets/lvextend
+++ b/sheets/lvextend
@@ -1,21 +1,23 @@
 # lvextend
-# Extends a logical volume in an existing volume group.
-# A volume group is a collection of logical and physical volumes.
+# Extend the size of a logical volume.
 
-# Extend volume in volume mylv in group vg0
-# (defined by volume path /dev/vg0/mylv)
-# to 12 gigabyte:
-lvextend -L 12G /dev/vg0/mylv
+# Extend a logical volume by a specific size (e.g., 10GB)
+lvextend -L +10G /dev/vg_name/lv_name
 
-# Extend volume in volume mylv in group vg0
-# (defined by volume path /dev/vg0/mylv)
-# by 1 gigabyte:
-lvextend -L +1G /dev/vg0/mylv
+# Extend a logical volume to a specific size (e.g., 50GB)
+lvextend -L 50G /dev/vg_name/lv_name
 
-# Extend volume in volume mylv in group vg0
-# (defined by volume path /dev/vg0/mylv)
-# to use all of the unallocated space in the volume group vg0:
-lvextend -l +100%FREE /dev/vg0/mylv
+# Extend a logical volume using all the available space in the volume group
+lvextend -l +100%FREE /dev/vg_name/lv_name
+
+# Extend a logical volume on a specific physical volume
+lvextend -L +5G /dev/vg_name/lv_name /dev/sdX
+
+# Extend a logical volume and resize the filesystem on the fly (for ext2/ext3/ext4 file systems)
+lvextend -r -L +10G /dev/vg_name/lv_name
+
+# Extend a logical volume to use all the remaining unallocated space in the group and resize the filesystem
+lvextend -r -l +100%FREE /dev/vg_name/lv_name
 
 # Extend ext4 filesystem after changing a logical volume
 # (takes volume path as parameter):

--- a/sheets/lvm
+++ b/sheets/lvm
@@ -1,0 +1,38 @@
+# lvm
+# Activate the LVM2 command-line interface.
+
+# List all existing volume groups
+lvm vgs
+
+# Display detailed information about all physical volumes
+lvm pvs -v
+
+# Activate a specific logical volume
+lvm lvchange -ay /dev/VolumeGroupName/LogicalVolumeName
+
+# Deactivate a specific logical volume
+lvm lvchange -an /dev/VolumeGroupName/LogicalVolumeName
+
+# Create a new logical volume with a specified size
+lvm lvcreate -L 10G -n LogicalVolumeName VolumeGroupName
+
+# Resize an existing logical volume
+lvm lvresize -L +5G /dev/VolumeGroupName/LogicalVolumeName
+
+# Remove a logical volume
+lvm lvremove /dev/VolumeGroupName/LogicalVolumeName
+
+# Display detailed information about logical volumes
+lvm lvs -v
+
+# Extend a volume group by adding a physical volume
+lvm vgextend VolumeGroupName /dev/sdX
+
+# Create a new volume group
+lvm vgcreate VolumeGroupName /dev/sdX
+
+# Reduce a volume group by removing a physical volume
+lvm vgreduce VolumeGroupName /dev/sdX
+
+# Remove a volume group
+lvm vgremove VolumeGroupName

--- a/sheets/lvmconfig
+++ b/sheets/lvmconfig
@@ -1,4 +1,0 @@
-# lvmconfig
-# Display and manipulate LVM configuration.
-
-NOT_SURE

--- a/sheets/lvmconfig
+++ b/sheets/lvmconfig
@@ -1,0 +1,4 @@
+# lvmconfig
+# Display and manipulate LVM configuration.
+
+NOT_SURE

--- a/sheets/lvmdiskscan
+++ b/sheets/lvmdiskscan
@@ -1,0 +1,17 @@
+# lvmdiskscan
+# List devices that may be used as physical volumes.
+
+# Basic usage: Lists all devices that may be used as physical volumes
+lvmdiskscan
+
+# List devices with detailed information
+lvmdiskscan --verbose
+
+# Output the results in a format suitable for seeding a configuration file
+lvmdiskscan --dumpconfig
+
+# Exclude devices from being listed
+lvmdiskscan --ignorelockingfailure
+
+# Display the command version
+lvmdiskscan --version

--- a/sheets/lvmsadc
+++ b/sheets/lvmsadc
@@ -1,4 +1,0 @@
-# lvmsadc
-# Collect activity data for LVM objects.
-
-NOT_SURE

--- a/sheets/lvmsadc
+++ b/sheets/lvmsadc
@@ -1,0 +1,4 @@
+# lvmsadc
+# Collect activity data for LVM objects.
+
+NOT_SURE

--- a/sheets/lvmsar
+++ b/sheets/lvmsar
@@ -1,0 +1,4 @@
+# lvmsar
+# Display historical LVM activity data.
+
+NOT_SURE

--- a/sheets/lvmsar
+++ b/sheets/lvmsar
@@ -1,4 +1,0 @@
-# lvmsar
-# Display historical LVM activity data.
-
-NOT_SURE

--- a/sheets/lvreduce
+++ b/sheets/lvreduce
@@ -1,0 +1,20 @@
+# lvreduce
+# Reduce the size of a logical volume.
+
+# Reducing the size of a logical volume
+lvreduce -L [size] [LogicalVolumePath]
+
+# Reducing the size of a logical volume by a certain amount
+lvreduce -L -[size] [LogicalVolumePath]
+
+# Simulating the reduction process to show what would happen
+lvreduce -t -L [size] [LogicalVolumePath]
+
+# Forcing the reduction even if consistency check fails
+lvreduce -f -L [size] [LogicalVolumePath]
+
+# Reducing the size of a logical volume and resizing the filesystem
+lvreduce -r -L [size] [LogicalVolumePath]
+
+# Reducing the size of a logical volume and specifying exact size in sectors
+lvreduce -l [number_of_logical_extents] [LogicalVolumePath]

--- a/sheets/lvremove
+++ b/sheets/lvremove
@@ -1,0 +1,23 @@
+# lvremove
+# Remove a logical volume.
+
+# Basic removal of a logical volume
+lvremove /dev/vg_name/lv_name
+
+# Forcefully remove a logical volume without prompt
+lvremove -f /dev/vg_name/lv_name
+
+# Remove multiple logical volumes at once
+lvremove /dev/vg_name/lv1_name /dev/vg_name/lv2_name
+
+# Remove a logical volume with a specific volume group
+lvremove vg_name/lv_name
+
+# Preview removing a logical volume without actually executing
+lvremove -t /dev/vg_name/lv_name
+
+# Remove a logical volume and suppress all output
+lvremove -q /dev/vg_name/lv_name
+
+# Remove a thin logical volume without a confirmation prompt
+lvremove -y /dev/vg_thinpool/thinlv_name

--- a/sheets/lvrename
+++ b/sheets/lvrename
@@ -1,0 +1,17 @@
+# lvrename
+# Rename a logical volume.
+
+# Rename a logical volume within the same volume group
+lvrename /dev/vg_name/old_lv_name /dev/vg_name/new_lv_name
+
+# Rename a logical volume by specifying the volume group name once
+lvrename vg_name old_lv_name new_lv_name
+
+# Rename a logical volume using the UUID
+lvrename --uuid old_lv_uuid /dev/vg_name/new_lv_name
+
+# Rename a logical volume and activate verbose mode to get more details
+lvrename -v /dev/vg_name/old_lv_name /dev/vg_name/new_lv_name
+
+# Test rename operation without making changes
+lvrename --test /dev/vg_name/old_lv_name /dev/vg_name/new_lv_name

--- a/sheets/lvresize
+++ b/sheets/lvresize
@@ -1,0 +1,29 @@
+# lvresize
+# Resize a logical volume.
+
+# Resize a logical volume to a specific size
+lvresize -L [size] [logical_volume]
+
+# Increase the size of a logical volume by a specific amount
+lvresize -L +[size] [logical_volume]
+
+# Reduce the size of a logical volume by a specific amount
+lvresize -L -[size] [logical_volume]
+
+# Resize a logical volume and extend the underlying filesystem automatically
+lvresize -r -L [size] [logical_volume]
+
+# Resize a logical volume to a percentage of the total VG size
+lvresize -l [percentage]%VG [logical_volume] 
+
+# Increase logical volume size by a percentage of the existing size
+lvresize -l +[percentage]% [logical_volume] 
+
+# Reduce logical volume size by a percentage of the existing size
+lvresize -l -[percentage]% [logical_volume] 
+
+# Resize a logical volume to fill all remaining free space in the volume group
+lvresize -l 100%FREE [logical_volume]
+
+# Resize a logical volume with a new size while keeping the original file system intact
+lvresize --nofsck -L [size] [logical_volume]

--- a/sheets/lvs
+++ b/sheets/lvs
@@ -1,0 +1,32 @@
+# lvs
+# Display information about logical volumes in concise form.
+
+# Display basic information about all logical volumes
+lvs
+
+# Display logical volume information with more details (use long listing format)
+lvs -v
+
+# Display logical volume information with units (e.g., KB, MB, GB)
+lvs --units g
+
+# Show all logical volumes sorted by size
+lvs --sort lv_size
+
+# Filter to display only logical volumes that belong to a specific volume group
+lvs my_volume_group
+
+# Display logical volumes in a columnar format, specifically showing only the volume size
+lvs --options lv_size
+
+# Suppress headings in the output for easier parsing
+lvs --noheadings
+
+# Display only active logical volumes
+lvs --select 'lv_active==active'
+
+# Display logical volumes with their attributes
+lvs --segments
+
+# Show logical volumes and their metadata in JSON format
+lvs --reportformat json

--- a/sheets/lvscan
+++ b/sheets/lvscan
@@ -1,0 +1,11 @@
+# lvscan
+# Scan for all logical volumes in the system.
+
+# Scan for all logical volumes in the system
+lvscan
+
+# Display all logical volumes with their associated attributes such as status and size
+lvscan --all
+
+# Scan and display logical volumes with additional detailed information
+lvscan --verbose

--- a/sheets/pvchange
+++ b/sheets/pvchange
@@ -1,0 +1,17 @@
+# pvchange
+# Change attributes of a physical volume.
+
+# Change the availability of a physical volume
+pvchange -x n /dev/sdX
+
+# Set physical volume not to be allocatable
+pvchange -x n /dev/sdX
+
+# Set physical volume to be allocatable
+pvchange -x y /dev/sdX
+
+# Change the metadata ignore flag of a physical volume
+pvchange --metadataignore y /dev/sdX
+
+# Enable 64-bit metadata on a physical volume
+pvchange --metadata-type lvm2 /dev/sdX

--- a/sheets/pvcreate
+++ b/sheets/pvcreate
@@ -1,0 +1,23 @@
+# pvcreate
+# Initialize a physical volume for use by LVM.
+
+# Initialize a disk or partition as a physical volume for LVM
+pvcreate /dev/sdx1
+
+# Initialize a disk or partition with specific metadata size
+pvcreate --metadatasize 128M /dev/sdx1
+
+# Initialize a disk or partition with zeroing of the first 4 sectors (default)
+pvcreate --zero y /dev/sdx1
+
+# Initialize a disk with sector size of 512 bytes
+pvcreate --dataalignment 512s /dev/sdx1
+
+# Set the physical volume label and initialize
+pvcreate --label my_physical_volume /dev/sdx1
+
+# Initialize with a specific UUID
+pvcreate --uuid abcdef12-3456-7890-abcd-ef1234567890 /dev/sdx1
+
+# Display detailed information about the operation being performed
+pvcreate --verbose /dev/sdx1

--- a/sheets/pvdisplay
+++ b/sheets/pvdisplay
@@ -1,0 +1,23 @@
+# pvdisplay
+# Display information about physical volumes.
+
+# Display detailed information about all physical volumes
+pvdisplay
+
+# Display detailed information for a specific physical volume (replace "/dev/sdX" with the actual volume name)
+pvdisplay /dev/sdX
+
+# Display physical volume information with units in megabytes
+pvdisplay --units m
+
+# Show physical volume information with human-readable output
+pvdisplay --human-readable
+
+# Display only the physical volume(s) UUID
+pvdisplay -C --columns | awk '{print $1, $2}'
+
+# Show verbose output with additional details
+pvdisplay -v
+
+# Show version information
+pvdisplay --version

--- a/sheets/pvmove
+++ b/sheets/pvmove
@@ -1,0 +1,23 @@
+# pvmove
+# Move physical extents from one physical volume to another.
+
+# Move all physical extents from one physical volume to another
+pvmove /dev/sdX /dev/sdY
+
+# Move specific logical volumes from one physical volume to another
+pvmove --alloc anywhere /dev/sdX:/dev/sdY /dev/mapper/vgname-lvname
+
+# Move all physical extents while outputting verbose information
+pvmove -v /dev/sdX
+
+# Move physical extents while allowing uninitialized physical volumes as sources
+pvmove --ignoreskippedcluster /dev/sdX /dev/sdY
+
+# Move extents from any device belonging to a volume group to a specified device
+pvmove --alloc anywhere /dev/md0
+
+# Move physical extents using a temporary mirror, reading from and writing to specified devices
+pvmove --atomic pvname[:pe_ranges] [destpv[:pe_ranges] [movedevice[:pe_ranges]]]
+
+# Abort a pvmove operation in progress
+pvmove --abort

--- a/sheets/pvremove
+++ b/sheets/pvremove
@@ -1,0 +1,14 @@
+# pvremove
+# Remove a physical volume.
+
+# Remove a physical volume from LVM
+pvremove /dev/sdX
+
+# Remove a physical volume with a warning prompt (use -ff to force and skip prompts)
+pvremove -ff /dev/sdX
+
+# Remove a physical volume while suppressing all output and warnings
+pvremove -q /dev/sdX
+
+# Remove multiple physical volumes at once
+pvremove /dev/sdX /dev/sdY '/dev/mapper/volume_name'

--- a/sheets/pvresize
+++ b/sheets/pvresize
@@ -1,0 +1,17 @@
+# pvresize
+# Resize a physical volume.
+
+# Resize a physical volume to use all available space on the underlying block device
+pvresize /dev/sdX
+
+# Resize a physical volume to a specific size (e.g., 10GB)
+pvresize --setphysicalvolumesize 10G /dev/sdX
+
+# Resize a physical volume to the available size on the underlying block device without confirmation
+pvresize --yes /dev/sdX
+
+# Force resize even if the PV is not the last one on the underlying block device
+pvresize --force /dev/sdX
+
+# Display help information about pvresize command usage
+pvresize --help

--- a/sheets/pvs
+++ b/sheets/pvs
@@ -1,0 +1,32 @@
+# pvs
+# Display information about physical volumes in concise form.
+
+# Display basic information about physical volumes
+pvs
+
+# Display verbose information about physical volumes, including details such as UUID
+pvs -v
+
+# Display physical volumes with specific columns: physical volume name, volume group name, and size
+pvs --columns pv_name,vg_name,pv_size
+
+# Display physical volumes in a human-readable format, converting size units
+pvs --units h
+
+# Show physical volumes sorted by size
+pvs --sort pv_size
+
+# Display information about physical volumes with additional device filter
+pvs /dev/sdX1
+
+# Display information about physical volumes with a header only once for better readability
+pvs --noheadings
+
+# Display physical volumes with size information in megabytes
+pvs --units M
+
+# Show physical volumes with a warning if any are using a missing data segment
+pvs --segments
+
+# Display the status of the physical volumes including allocatable and missing status
+pvs -o +allocatable,missing

--- a/sheets/pvscan
+++ b/sheets/pvscan
@@ -1,0 +1,17 @@
+# pvscan
+# Scan all disks for physical volumes.
+
+# Scan all disks for LVM physical volumes
+pvscan
+
+# Show physical volumes and update the VG and LVM metadata to reflect changes
+pvscan --cache
+
+# Scan specific devices for physical volumes
+pvscan /dev/sda /dev/sdb
+
+# Display version information
+pvscan --version
+
+# Display help information
+pvscan --help

--- a/sheets/vgchange
+++ b/sheets/vgchange
@@ -1,0 +1,26 @@
+# vgchange
+# Change attributes of a volume group.
+
+# Activate all the volume groups
+vgchange -a y
+
+# Deactivate a specific volume group
+vgchange -a n VolumeGroupName
+
+# Set the maximum number of logical volumes for a volume group
+vgchange -l MaxLogicalVolumes VolumeGroupName
+
+# Set the maximum number of physical volumes for a volume group
+vgchange -p MaxPhysicalVolumes VolumeGroupName
+
+# Change the writeability attribute of a volume group (e.g., make it read-only)
+vgchange -a r VolumeGroupName
+
+# Resize or reset the physical extent size of a volume group
+vgchange --resizeable y VolumeGroupName
+
+# Temporarily change the number of concurrent allocation processes (use only for tuning)
+vgchange --allocations 2 VolumeGroupName
+
+# Enable cluster infrastructure for a volume group (requires clustering software)
+vgchange --clustered y VolumeGroupName

--- a/sheets/vgconvert
+++ b/sheets/vgconvert
@@ -1,0 +1,20 @@
+# vgconvert
+# Convert a volume group metadata format.
+
+# Convert a volume group to the latest metadata format
+vgconvert --force vg_name
+
+# Convert a volume group to the LVM1 metadata format
+vgconvert --type lvm1 vg_name
+
+# Convert a volume group to the LVM2 metadata format
+vgconvert --type lvm2 vg_name
+
+# Convert a clustered volume group to a non-clustered volume group
+vgconvert --remove-clustered vg_name
+
+# Convert a non-clustered volume group to a clustered volume group
+vgconvert --add-clustered vg_name
+
+# Preview the conversion without making any changes
+vgconvert --test vg_name

--- a/sheets/vgcreate
+++ b/sheets/vgcreate
@@ -1,0 +1,20 @@
+# vgcreate
+# Create a new volume group.
+
+# Create a new volume group with specific name and physical volumes
+vgcreate <volume_group_name> <physical_volume_paths>
+
+# Create a new volume group with a specific physical extent size
+vgcreate --physicalextentsize <size> <volume_group_name> <physical_volume_paths>
+
+# Create a new volume group with a maximum number of logical volumes that can be created
+vgcreate --maxlogicalvolumes <number> <volume_group_name> <physical_volume_paths>
+
+# Create a new volume group with a maximum number of physical volumes that can be included
+vgcreate --maxphysicalvolumes <number> <volume_group_name> <physical_volume_paths>
+
+# Create a new volume group with metadata to be stored in a specific format (lvm1 or lvm2)
+vgcreate --metadatatype <type> <volume_group_name> <physical_volume_paths>
+
+# Create a new volume group while specifying allocation policy (e.g., contiguous, cling, normal)
+vgcreate --alloc <policy> <volume_group_name> <physical_volume_paths>

--- a/sheets/vgdisplay
+++ b/sheets/vgdisplay
@@ -1,0 +1,26 @@
+# vgdisplay
+# Display information about volume groups.
+
+# Display information about all volume groups
+vgdisplay
+
+# Display information about a specific volume group
+vgdisplay volume_group_name
+
+# Display information about all volume groups with more detailed output
+vgdisplay -v
+
+# Display information about a specific volume group with more detailed output
+vgdisplay -v volume_group_name
+
+# Display only the names of the volume groups
+vgdisplay -c | cut -d ':' -f 1
+
+# Display information in units of megabytes
+vgdisplay --units m
+
+# Display information in a verbose and machine-readable format
+vgdisplay -C -o vg_name,lv_count,lv_size,pv_count,pv_size,vg_free
+
+# Display the size of the volume group in human-readable format
+vgdisplay --units h volume_group_name

--- a/sheets/vgextend
+++ b/sheets/vgextend
@@ -1,0 +1,17 @@
+# vgextend
+# Extend a volume group by adding physical volumes.
+
+# Extend an existing volume group by adding a new physical volume
+vgextend <volume_group_name> <physical_volume_path>
+
+# Extend a volume group by adding multiple physical volumes at once
+vgextend <volume_group_name> <physical_volume_path1> <physical_volume_path2> <physical_volume_path3>
+
+# Extend a volume group with verbose output to see detailed information
+vgextend --verbose <volume_group_name> <physical_volume_path>
+
+# Extend a volume group by adding a physical volume while specifying the physical volume as a UUID
+vgextend <volume_group_name> /dev/disk/by-id/<physical_volume_uuid>
+
+# Extend a volume group while making a backup of metadata before the extension
+vgextend --backup <volume_group_name> <physical_volume_path>

--- a/sheets/vgmerge
+++ b/sheets/vgmerge
@@ -1,0 +1,14 @@
+# vgmerge
+# Merge two volume groups.
+
+# Explanation: Basic usage to merge two volume groups
+vgmerge destination_vg source_vg
+
+# Explanation: Merge two volume groups in verbose mode, displaying detailed output of the process
+vgmerge -v destination_vg source_vg
+
+# Explanation: Test merge of two volume groups without actually making any changes
+vgmerge -t destination_vg source_vg
+
+# Explanation: Force the merge of two volume groups, even if the destination volume group is already active
+vgmerge -f destination_vg source_vg

--- a/sheets/vgreduce
+++ b/sheets/vgreduce
@@ -1,0 +1,17 @@
+# vgreduce
+# Reduce a volume group by removing physical volumes.
+
+# Remove a specific physical volume from a volume group
+vgreduce my_volume_group /dev/sdX1
+
+# Remove all missing physical volumes from a volume group
+vgreduce --removemissing my_volume_group
+
+# Remove a physical volume from a volume group with verbose output
+vgreduce --verbose my_volume_group /dev/sdX1
+
+# Reduce the volume group by removing a physical volume forcefully
+vgreduce --force my_volume_group /dev/sdX1
+
+# Remove a physical volume from a volume group without confirming (use with caution)
+vgreduce --yes my_volume_group /dev/sdX1

--- a/sheets/vgremove
+++ b/sheets/vgremove
@@ -1,0 +1,23 @@
+# vgremove
+# Remove a volume group.
+
+# Remove a volume group named "my_volume_group"
+vgremove my_volume_group
+
+# Forcefully remove a volume group without prompt, using the '-f' option
+vgremove -f my_volume_group
+
+# Use '-v' for verbose output while removing the volume group
+vgremove -v my_volume_group
+
+# Remove a volume group and use '--force' to avoid interactive confirmation
+vgremove --force my_volume_group
+
+# Remove multiple volume groups at once
+vgremove volume_group1 volume_group2
+
+# Use '-A' to set auto-activation to 'n' for not activating any logical volumes on start-up
+vgremove -A n my_volume_group
+
+# Remove a volume group but proceed even if some logical volumes do not exist with '--removemissing'
+vgremove --removemissing my_volume_group

--- a/sheets/vgrename
+++ b/sheets/vgrename
@@ -1,0 +1,11 @@
+# vgrename
+# Rename a volume group.
+
+# Rename a volume group from old_name to new_name
+vgrename old_name new_name
+
+# Rename a volume group identified by its UUID
+vgrename UUID new_name
+
+# Rename a volume group with additional option to check for size compatibility
+vgrename --sizecheck old_name new_name

--- a/sheets/vgs
+++ b/sheets/vgs
@@ -1,0 +1,35 @@
+# vgs
+# Display information about volume groups in concise form.
+
+# Display all volume groups in a concise form
+vgs
+
+# Display specific volume group information
+vgs [VolumeGroupName]
+
+# Display volume groups with specific fields (e.g., VG name and size)
+vgs --options vg_name,vg_size
+
+# Display volume groups and filter results using a keyword (e.g., "root")
+vgs | grep root
+
+# Show volume group information with units in human-readable format
+vgs --units h
+
+# Display output in columns
+vgs --separator :
+
+# Show detailed help about the vgs command
+vgs --help
+
+# Display volume groups with additional information (e.g., tags, etc.)
+vgs --options +tags
+
+# Sort volume groups by size
+vgs --sort vg_size
+
+# Display volume groups in a specific format
+vgs --reportformat basic
+
+# Display volume group information in JSON format
+vgs --reportformat json

--- a/sheets/vgscan
+++ b/sheets/vgscan
@@ -1,0 +1,20 @@
+# vgscan
+# Scan all disks for volume groups.
+
+# Scan all physical volumes for volume groups
+vgscan
+
+# Scan all disks for volume groups without updating the cache
+vgscan --ignorelockingfailure
+
+# Scan and print the current volume group names without performing any changes
+vgscan --readonly
+
+# Run vgscan with verbose output
+vgscan --verbose
+
+# Run vgscan with debugging information output
+vgscan --debug
+
+# Scan all disks and force a re-read of the metadata
+vgscan --mknodes

--- a/sheets/vgsplit
+++ b/sheets/vgsplit
@@ -1,0 +1,20 @@
+# vgsplit
+# Split a volume group into two volume groups.
+
+# Split a volume group 'vg1' into two separate volume groups 'vg1' and 'vg2', moving logical volume 'lv1' to 'vg2'
+vgsplit vg1 vg2 /dev/vg1/lv1
+
+# Split a volume group 'vg-source' into 'vg-destination', specifying the physical volume '/dev/sdXY' to move
+vgsplit vg-source vg-destination /dev/sdXY
+
+# Maintain metadata backup of volume groups while splitting
+vgsplit --metadatacopies 2 vg1 vg2 /dev/vg1/lv1
+
+# Split a volume group and skip any prompts by confirming all changes automatically
+vgsplit --yes vg1 vg2 /dev/vg1/lv1
+
+# Split a volume group with verbose output to show detailed operations during the split
+vgsplit --verbose vg1 vg2 /dev/vg1/lv1
+
+# When running as part of a script, suppress all output except error messages
+vgsplit --quiet vg1 vg2 /dev/vg1/lv1

--- a/topics/lvm.json
+++ b/topics/lvm.json
@@ -1,0 +1,146 @@
+[
+  {
+    "command": "lvchange",
+    "description": "Change attributes of a logical volume."
+  },
+  {
+    "command": "lvconvert",
+    "description": "Convert a logical volume from linear to mirror or RAID."
+  },
+  {
+    "command": "lvcreate",
+    "description": "Create a new logical volume."
+  },
+  {
+    "command": "lvdisplay",
+    "description": "Display information about logical volumes."
+  },
+  {
+    "command": "lvextend",
+    "description": "Extend the size of a logical volume."
+  },
+  {
+    "command": "lvm",
+    "description": "Activate the LVM2 command-line interface."
+  },
+  {
+    "command": "lvmconfig",
+    "description": "Display and manipulate LVM configuration."
+  },
+  {
+    "command": "lvmdiskscan",
+    "description": "List devices that may be used as physical volumes."
+  },
+  {
+    "command": "lvmsadc",
+    "description": "Collect activity data for LVM objects."
+  },
+  {
+    "command": "lvmsar",
+    "description": "Display historical LVM activity data."
+  },
+  {
+    "command": "lvreduce",
+    "description": "Reduce the size of a logical volume."
+  },
+  {
+    "command": "lvremove",
+    "description": "Remove a logical volume."
+  },
+  {
+    "command": "lvrename",
+    "description": "Rename a logical volume."
+  },
+  {
+    "command": "lvresize",
+    "description": "Resize a logical volume."
+  },
+  {
+    "command": "lvs",
+    "description": "Display information about logical volumes in concise form."
+  },
+  {
+    "command": "lvscan",
+    "description": "Scan for all logical volumes in the system."
+  },
+  {
+    "command": "pvchange",
+    "description": "Change attributes of a physical volume."
+  },
+  {
+    "command": "pvcreate",
+    "description": "Initialize a physical volume for use by LVM."
+  },
+  {
+    "command": "pvdisplay",
+    "description": "Display information about physical volumes."
+  },
+  {
+    "command": "pvmove",
+    "description": "Move physical extents from one physical volume to another."
+  },
+  {
+    "command": "pvremove",
+    "description": "Remove a physical volume."
+  },
+  {
+    "command": "pvresize",
+    "description": "Resize a physical volume."
+  },
+  {
+    "command": "pvs",
+    "description": "Display information about physical volumes in concise form."
+  },
+  {
+    "command": "pvscan",
+    "description": "Scan all disks for physical volumes."
+  },
+  {
+    "command": "vgchange",
+    "description": "Change attributes of a volume group."
+  },
+  {
+    "command": "vgconvert",
+    "description": "Convert a volume group metadata format."
+  },
+  {
+    "command": "vgcreate",
+    "description": "Create a new volume group."
+  },
+  {
+    "command": "vgdisplay",
+    "description": "Display information about volume groups."
+  },
+  {
+    "command": "vgextend",
+    "description": "Extend a volume group by adding physical volumes."
+  },
+  {
+    "command": "vgmerge",
+    "description": "Merge two volume groups."
+  },
+  {
+    "command": "vgreduce",
+    "description": "Reduce a volume group by removing physical volumes."
+  },
+  {
+    "command": "vgremove",
+    "description": "Remove a volume group."
+  },
+  {
+    "command": "vgrename",
+    "description": "Rename a volume group."
+  },
+  {
+    "command": "vgs",
+    "description": "Display information about volume groups in concise form."
+  },
+  {
+    "command": "vgscan",
+    "description": "Scan all disks for volume groups."
+  },
+  {
+    "command": "vgsplit",
+    "description": "Split a volume group into two volume groups."
+  }
+]


### PR DESCRIPTION
| **Command**   | **Command Description**                                                          |
|---------------|----------------------------------------------------------------------------------|
| `lvchange`    | Change attributes of a logical volume.                                           |
| `lvconvert`   | Convert a logical volume from linear to mirror or RAID.                          |
| `lvcreate`    | Create a new logical volume.                                                     |
| `lvdisplay`   | Display information about logical volumes.                                       |
| `lvextend`    | Extend the size of a logical volume.                                             |
| `lvm`         | Activate the LVM2 command-line interface.                                        |
| `lvmconfig`   | Display and manipulate LVM configuration.                                        |
| `lvmdiskscan` | List devices that may be used as physical volumes.                               |
| `lvmsadc`     | Collect activity data for LVM objects.                                           |
| `lvmsar`      | Display historical LVM activity data.                                            |
| `lvreduce`    | Reduce the size of a logical volume.                                             |
| `lvremove`    | Remove a logical volume.                                                         |
| `lvrename`    | Rename a logical volume.                                                         |
| `lvresize`    | Resize a logical volume.                                                         |
| `lvs`         | Display information about logical volumes in concise form.                       |
| `lvscan`      | Scan for all logical volumes in the system.                                      |
| `pvchange`    | Change attributes of a physical volume.                                          |
| `pvcreate`    | Initialize a physical volume for use by LVM.                                     |
| `pvdisplay`   | Display information about physical volumes.                                      |
| `pvmove`      | Move physical extents from one physical volume to another.                       |
| `pvremove`    | Remove a physical volume.                                                        |
| `pvresize`    | Resize a physical volume.                                                        |
| `pvs`         | Display information about physical volumes in concise form.                      |
| `pvscan`      | Scan all disks for physical volumes.                                             |
| `vgchange`    | Change attributes of a volume group.                                             |
| `vgconvert`   | Convert a volume group metadata format.                                          |
| `vgcreate`    | Create a new volume group.                                                       |
| `vgdisplay`   | Display information about volume groups.                                         |
| `vgextend`    | Extend a volume group by adding physical volumes.                                |
| `vgmerge`     | Merge two volume groups.                                                         |
| `vgreduce`    | Reduce a volume group by removing physical volumes.                              |
| `vgremove`    | Remove a volume group.                                                           |
| `vgrename`    | Rename a volume group.                                                           |
| `vgs`         | Display information about volume groups in concise form.                         |
| `vgscan`      | Scan all disks for volume groups.                                                |
| `vgsplit`     | Split a volume group into two volume groups.                                     |