### PR TITLE
Add Pulse Audio cheat sheets

### DIFF
--- a/sheets/pacat
+++ b/sheets/pacat
@@ -1,0 +1,29 @@
+# pacat
+# Play audio using PulseAudio.
+
+# Play an audio file using pacat
+pacat --file /path/to/audiofile
+
+# Record audio to a file using pacat
+pacat --record --file /path/to/outputfile
+
+# Play audio from stdin
+cat /path/to/audiofile | pacat
+
+# Record audio from a microphone to stdout
+pacat --record > output.raw
+
+# Play audio with verbose logging
+pacat --verbose --file /path/to/audiofile
+
+# Specify audio format (e.g., s16le, s16be, u8)
+pacat --file-format s16le --file /path/to/audiofile
+
+# Set the audio sample rate
+pacat --rate 44100 --file /path/to/audiofile
+
+# Adjust audio channel number
+pacat --channels 2 --file /path/to/audiofile
+
+# Specify a device for output or input
+pacat --device alsa_output.pci-0000_00_1f.3.analog-stereo --file /path/to/audiofile

--- a/sheets/pacmd
+++ b/sheets/pacmd
@@ -1,0 +1,51 @@
+# pacmd
+# Control PulseAudio servers from the command line.
+
+# List all loaded modules
+pacmd list-modules
+
+# List all sinks (output devices)
+pacmd list-sinks
+
+# List all sources (input devices)
+pacmd list-sources
+
+# List all clients connected to the PulseAudio server
+pacmd list-clients
+
+# List all loaded cards
+pacmd list-cards
+
+# List all active audio streams
+pacmd list-sink-inputs
+pacmd list-source-outputs
+
+# Set the default sink (output device)
+pacmd set-default-sink <sink_name_or_index>
+
+# Set the default source (input device)
+pacmd set-default-source <source_name_or_index>
+
+# Move a sink input to a different sink
+pacmd move-sink-input <input_index> <sink_name_or_index>
+
+# Move a source output to a different source
+pacmd move-source-output <output_index> <source_name_or_index>
+
+# Load a module
+pacmd load-module <module_name> [arguments]
+
+# Unload a module
+pacmd unload-module <module_index_or_name>
+
+# Set the volume of a sink (output device)
+pacmd set-sink-volume <sink_name_or_index> <volume>
+
+# Set the mute status of a sink (output device)
+pacmd set-sink-mute <sink_name_or_index> <yes|no>
+
+# Set the volume of a source (input device)
+pacmd set-source-volume <source_name_or_index> <volume>
+
+# Set the mute status of a source (input device)
+pacmd set-source-mute <source_name_or_index> <yes|no>

--- a/sheets/pactl
+++ b/sheets/pactl
@@ -1,10 +1,44 @@
 # pactl
-# Control a running PulseAudio sound server
+# Control a running PulseAudio sound server.
+
+# List all loaded modules
+pactl list modules
+
+# Load a module
+pactl load-module module-name
+
+# Unload a module by its index
+pactl unload-module module-index
+
+# List all available sinks (output devices)
+pactl list sinks
+
+# List all available sources (input devices)
+pactl list sources
+
+# Set the default sink (output device) by its name
+pactl set-default-sink sink-name
+
+# Set the default source (input device) by its name
+pactl set-default-source source-name
+
+# Set the volume of a sink (output device) by its name or index to 50%
+pactl set-sink-volume sink-name-or-index 50%
+
+# Mute a sink (output device) by its index
+pactl set-sink-mute sink-index 1
+
+# Unmute a sink (output device) by its index
+pactl set-sink-mute sink-index 0
+
+# Move a sink input (audio stream) to a different sink by their index
+pactl move-sink-input sink-input-index sink-index
+
+# Kill a client by its index
+pactl kill-client client-index
+
+# Kill a sink input by its index
+pactl kill-sink-input sink-input-index
 
 # Display a sorted and uniq-ified list of PulseAudio modules, using AWK.
 pactl list modules short | awk '{!Lines[$2]++} END {asorti(Lines, Sorted); for (Line in Sorted) print(Sorted[Line])}'
-
-# Load a module.
-pactl load-module MODULE
-# Unload a module.
-pactl unload-module MODULE

--- a/sheets/pactl-load-module
+++ b/sheets/pactl-load-module
@@ -1,0 +1,23 @@
+# pactl load-module
+# Load a module into the PulseAudio sound server.
+
+# Load a module into the PulseAudio sound server
+pactl load-module <module-name> [arguments]
+
+# Load the null-sink module, creating a virtual output device
+pactl load-module module-null-sink sink_name=Virtual_Sink
+
+# Load the loopback module to route audio from a source to a sink
+pactl load-module module-loopback source=<source_name_or_index> sink=<sink_name_or_index>
+
+# Load the RTP (Real-time Transport Protocol) receiver module for network audio streaming
+pactl load-module module-rtp-recv
+
+# Load the RTP sender module and specify the destination IP address for network audio streaming
+pactl load-module module-rtp-send destination_ip=<ip_address> sink=<sink_name_or_index>
+
+# Load the module-combine-sink to combine multiple sinks into a single virtual sink
+pactl load-module module-combine-sink sink_properties=device.description=Combined virtual_sinks="<sink1>,<sink2>"
+
+# Load the module-remap-sink to remap channels for custom audio routing
+pactl load-module module-remap-sink sink_name=Remapped_Sink master=<sink_name_or_index> channels=<channel_count> channel_map=<map>

--- a/sheets/pactl-unload-module
+++ b/sheets/pactl-unload-module
@@ -1,0 +1,11 @@
+# pactl unload-module
+# Unload a module from the PulseAudio sound server.
+
+# Unloads a specific module by its module number
+pactl unload-module MODULE_NUMBER
+
+# Unloads a module using a shell command substitution to fetch the module number dynamically
+pactl unload-module $(pactl list short modules | grep MODULE_NAME | cut -f1)
+
+# Use case where you know the module name and want to unload all instances of it
+for module in $(pactl list short modules | grep MODULE_NAME | cut -f1); do pactl unload-module $module; done

--- a/sheets/pamon
+++ b/sheets/pamon
@@ -1,0 +1,23 @@
+# pamon
+# Monitor audio streams in PulseAudio.
+
+# Monitor the default audio stream
+pamon
+
+# Monitor a specific sink (output device)
+pamon --sink <sink_index>
+
+# Monitor a specific source (input device)
+pamon --source <source_index>
+
+# Monitor a specific audio channel
+pamon --channel <channel_index>
+
+# Monitor with more detailed output, including volume and other parameters
+pamon --verbose
+
+# Monitor audio streams with a defined latency in microseconds
+pamon --latency <microseconds>
+
+# Use a custom server instead of the default
+pamon --server <server_name>

--- a/sheets/paplay
+++ b/sheets/paplay
@@ -1,0 +1,23 @@
+# paplay
+# Play audio files via PulseAudio.
+
+# Play an audio file (e.g., WAV or OGG) using the default PulseAudio server
+paplay /path/to/audiofile.wav
+
+# Play an audio file specifying a particular PulseAudio server to use
+paplay --server=SERVER /path/to/audiofile.wav
+
+# Play an audio file specifying a specific sink (output device)
+paplay --device=SINK_NAME /path/to/audiofile.wav
+
+# Play an audio file and set the volume (0-65536) for the playback
+paplay --volume=VOLUME /path/to/audiofile.wav
+
+# Play an audio file in a loop until interrupted
+while true; do paplay /path/to/audiofile.wav; done
+
+# Play multiple audio files in succession
+paplay /path/to/audiofile1.wav /path/to/audiofile2.wav
+
+# Play an audio file with environmental variable to change PulseAudio server (useful in scripts)
+PULSE_SERVER=SERVER paplay /path/to/audiofile.wav

--- a/sheets/parec
+++ b/sheets/parec
@@ -1,0 +1,23 @@
+# parec
+# Record audio directly from a PulseAudio sound server.
+
+# Record audio from the default source and save it to a file
+parec --format=s16le --rate=44100 --channels=2 > output.raw
+
+# Record audio from a specific source using its name
+parec --device=source_name --format=s16le --rate=44100 --channels=2 > output.raw
+
+# List available sources
+pactl list short sources
+
+# Record audio and encode to WAV format using sox
+parec --format=s16le --rate=44100 --channels=2 | sox -t raw -r 44100 -e signed-integer -b 16 -c 2 - output.wav
+
+# Record audio and compress it to MP3 format using lame
+parec --format=s16le --rate=44100 --channels=2 | lame -r -s 44.1 - output.mp3
+
+# Adjust the recording volume through volume scaling
+parec --volume=65536 --format=s16le --rate=44100 --channels=2 > output.raw
+
+# Specify a buffer size for recording
+parec --buffer-time=500000 --format=s16le --rate=44100 --channels=2 > output.raw

--- a/sheets/parec-simple
+++ b/sheets/parec-simple
@@ -1,0 +1,20 @@
+# parec-simple
+# Record audio from PulseAudio with simple output.
+
+# Record audio from the default source and save it to a file named output.wav
+parec-simple output.wav
+
+# Record audio and specify the desired audio format using the -f option (e.g., S16LE for 16-bit little-endian format)
+parec-simple -f S16LE output.wav
+
+# Specify the sample rate with the -r option (e.g., 44100 Hz)
+parec-simple -r 44100 output.wav
+
+# Record audio from a specific PulseAudio source (e.g., monitor source) and save it to a file
+parec-simple -d <source_name> output.wav
+
+# Record audio and specify the number of recording channels with the -c option (e.g., 2 for stereo)
+parec-simple -c 2 output.wav
+
+# Record audio and save it directly to stdout (useful for piping into other commands)
+parec-simple -o - | other_command

--- a/sheets/pasuspender
+++ b/sheets/pasuspender
@@ -1,0 +1,20 @@
+# pasuspender
+# Temporarily suspend PulseAudio for another application.
+
+# Temporarily suspend PulseAudio and run a specific command
+pasuspender -- my_command
+
+# Disable PulseAudio while running an application with specific options
+pasuspender -- my_command --option val
+
+# Run a multimedia application without PulseAudio interference
+pasuspender -- vlc my_video_file
+
+# Temporarily suspend PulseAudio to execute a script
+pasuspender -- ./myscript.sh
+
+# Run an application that conflicts with PulseAudio, like JACK
+pasuspender -- jackd -dalsa
+
+# Suspend PulseAudio for testing and debugging purposes
+pasuspender -- aplay test.wav

--- a/sheets/pulseaudio
+++ b/sheets/pulseaudio
@@ -1,0 +1,35 @@
+# pulseaudio
+# A networked sound server for UNIX systems.
+
+# Start the PulseAudio sound server
+pulseaudio --start
+
+# Stop the PulseAudio sound server
+pulseaudio --kill
+
+# Check the version of PulseAudio
+pulseaudio --version
+
+# Display help information
+pulseaudio --help
+
+# Start PulseAudio in a no-daemon mode (remains in the foreground)
+pulseaudio --no-daemon
+
+# Log to a specific file
+pulseaudio --log-target=file:/path/to/logfile
+
+# Specify the verbosity level of logging
+pulseaudio -vv
+
+# Specify an alternate configuration file
+pulseaudio --file=/path/to/config.file
+
+# Start PulseAudio with high-priority scheduling
+pulseaudio --high-priority
+
+# Disable real-time scheduling
+pulseaudio --disable-realtime
+
+# Enable PulseAudio as a system-wide instance (needs root privileges)
+sudo pulseaudio --system

--- a/topics/pulseaudio.json
+++ b/topics/pulseaudio.json
@@ -1,0 +1,70 @@
+[
+  {
+    "command": "pacat",
+    "description": "Play audio using PulseAudio."
+  },
+  {
+    "command": "pacmd",
+    "description": "Control PulseAudio servers from the command line."
+  },
+  {
+    "command": "pactl",
+    "description": "Control a running PulseAudio sound server."
+  },
+  {
+    "command": "pactl load-module",
+    "description": "Load a module into the PulseAudio sound server."
+  },
+  {
+    "command": "pactl unload-module",
+    "description": "Unload a module from the PulseAudio sound server."
+  },
+  {
+    "command": "padevchooser",
+    "description": "Choose and control audio devices using a graphical interface."
+  },
+  {
+    "command": "pa-info",
+    "description": "Display information about PulseAudio settings."
+  },
+  {
+    "command": "paman",
+    "description": "PulseAudio Manager graphical interface."
+  },
+  {
+    "command": "pamon",
+    "description": "Monitor audio streams in PulseAudio."
+  },
+  {
+    "command": "paplay",
+    "description": "Play audio files via PulseAudio."
+  },
+  {
+    "command": "parec",
+    "description": "Record audio directly from a PulseAudio sound server."
+  },
+  {
+    "command": "parec-simple",
+    "description": "Record audio from PulseAudio with simple output."
+  },
+  {
+    "command": "pasuspender",
+    "description": "Temporarily suspend PulseAudio for another application."
+  },
+  {
+    "command": "pasystray",
+    "description": "System tray utility to control PulseAudio volume."
+  },
+  {
+    "command": "pavucontrol",
+    "description": "Graphical volume control tool for PulseAudio."
+  },
+  {
+    "command": "pavumeter",
+    "description": "Graphical audio level meter for PulseAudio."
+  },
+  {
+    "command": "pulseaudio",
+    "description": "A networked sound server for UNIX systems."
+  }
+]


### PR DESCRIPTION
| **Command**   | **Command Description**                                                          |
|---------------|----------------------------------------------------------------------------------|
| `pacat`       | Play audio using PulseAudio.                                                     |
| `pacmd`       | Control PulseAudio servers from the command line.                                |
| `pactl`       | Control a running PulseAudio sound server.                                       |
| `pactl load-module`| Load a module into the PulseAudio sound server.                                  |
| `pactl unload-module`| Unload a module from the PulseAudio sound server.                                |
| `padevchooser`| Choose and control audio devices using a graphical interface.                    |
| `pa-info`     | Display information about PulseAudio settings.                                   |
| `paman`       | PulseAudio Manager graphical interface.                                          |
| `pamon`       | Monitor audio streams in PulseAudio.                                             |
| `paplay`      | Play audio files via PulseAudio.                                                 |
| `parec`       | Record audio directly from a PulseAudio sound server.                            |
| `parec-simple`| Record audio from PulseAudio with simple output.                                 |
| `pasuspender` | Temporarily suspend PulseAudio for another application.                          |
| `pasystray`   | System tray utility to control PulseAudio volume.                                |
| `pavucontrol` | Graphical volume control tool for PulseAudio.                                    |
| `pavumeter`   | Graphical audio level meter for PulseAudio.                                      |
| `pulseaudio`  | A networked sound server for UNIX systems.                                       |