### PR TITLE
Add python code formatting tools cheat sheets

### DIFF
--- a/sheets/autoflake
+++ b/sheets/autoflake
@@ -1,0 +1,26 @@
+# autoflake
+# Removes unused imports and variables in Python code.
+
+# Remove all unused imports and variables in a Python file
+autoflake --in-place --remove-unused-variables script.py
+
+# Remove unused imports only (keep unused variables) in a Python file
+autoflake --in-place script.py
+
+# Remove unused imports and variables in multiple Python files recursively in a directory
+autoflake --in-place --remove-unused-variables --recursive directory_path
+
+# Remove unused imports and variables in a Python file and display the changes without modifying the file
+autoflake --remove-unused-variables script.py
+
+# Remove unused imports while ignoring the 'os' module
+autoflake --in-place --ignore-init-module-imports=os script.py
+
+# Specify max line length when reformatting lines while removing unused imports
+autoflake --in-place --remove-unused-variables --max-line-length=120 script.py
+
+# Combine with 'find' to process multiple files in different subdirectories
+find . -name "*.py" | xargs autoflake --in-place --remove-unused-variables
+
+# Combine with 'git' to clean up Python files changed in the last commit
+autoflake --in-place --remove-unused-variables $(git diff --name-only HEAD | grep '.py')

--- a/sheets/autopep8
+++ b/sheets/autopep8
@@ -1,0 +1,33 @@
+# autopep8
+# Automatically formats Python code to conform to the PEP 8 style guide.
+
+# Automatically format a Python file to conform to PEP 8
+autopep8 myfile.py
+
+# Format a Python file in-place (modifies the file directly)
+autopep8 --in-place myfile.py
+
+# Format all Python files in a directory and subdirectories recursively
+autopep8 --in-place --recursive my_directory/
+
+# Format a Python file and display the differences only (without changing the file)
+autopep8 --diff myfile.py
+
+# Aggressively apply formatting changes (can be used multiple times for more aggressive changes)
+autopep8 --aggressive myfile.py
+autopep8 --aggressive --aggressive myfile.py
+
+# Specify a maximum line length (default is 79)
+autopep8 --max-line-length 100 myfile.py
+
+# Ignore specific PEP 8 errors or warnings
+autopep8 --ignore=E501 myfile.py
+
+# Apply fixes for specific PEP 8 errors or warnings only
+autopep8 --select=E123,W456 myfile.py
+
+# Use autopep8 to format code from standard input (stdin)
+cat myfile.py | autopep8 -
+
+# Apply autopep8 and also output statistics about changes made
+autopep8 --in-place --verbose myfile.py

--- a/sheets/bandit
+++ b/sheets/bandit
@@ -1,0 +1,32 @@
+# bandit
+# A tool designed to find security issues in Python code.
+
+# Run Bandit on a Python file to check for security issues
+bandit -r path/to/your/python_file.py
+
+# Run Bandit on a directory recursively to find security issues in all Python files
+bandit -r path/to/your/directory
+
+# Specify output format (e.g., JSON)
+bandit -f json -r path/to/your/directory
+
+# Generate a report and save it to a file
+bandit -r path/to/your/directory -o report.txt
+
+# Run Bandit with a specific severity level (e.g., low, medium, high)
+bandit -r path/to/your/directory -ll
+
+# Only show results for specific test plugins (e.g., B101, B102)
+bandit -s B101,B102 -r path/to/your/directory
+
+# Exclude specific test plugins from the scan
+bandit -x B403,B404 -r path/to/your/directory
+
+# Skip scanning code with known, safe issues using a configuration file
+bandit --configfile path/to/config.yaml -r path/to/your/directory
+
+# Display more verbose output
+bandit -v -r path/to/your/directory
+
+# Run Bandit with a custom profile
+bandit -p custom_profile.yml -r path/to/your/directory

--- a/sheets/black
+++ b/sheets/black
@@ -1,0 +1,47 @@
+# black
+# The uncompromising code formatter for Python that reformats entire files in place.
+
+# Format a single Python file
+black script.py
+
+# Format all Python files in a directory (recursively)
+black /path/to/directory
+
+# Check what files would be reformatted without making any changes
+black --check /path/to/directory
+
+# Display verbose output during formatting
+black --verbose script.py
+
+# Limit line length to a specified number of characters
+black --line-length 79 script.py
+
+# Skip nested .gitignore files
+black --skip-nested-glob-imports /path/to/directory
+
+# Use a specific configuration file
+black --config pyproject.toml script.py
+
+# Exclude specific files or directories using a regex
+black --exclude '/(\.venv|env)/' /path/to/directory
+
+# Include only specific files or directories using a regex
+black --include '.*_test.py' /path/to/directory
+
+# Run in quiet mode without output messages unless an error occurs
+black --quiet script.py
+
+# Automatically detect the target Python version (default behavior)
+black script.py
+
+# Specify a target Python version
+black --target-version py38 script.py
+
+# Only format files that were changed against a specific commit
+black --diff HEAD
+
+# Output a diff of what changes would be made
+black --diff script.py
+
+# Prevent writing back to files (use with --check or --diff)
+black --diff --check script.py

--- a/sheets/flake8
+++ b/sheets/flake8
@@ -1,0 +1,35 @@
+# flake8
+# A wrapper tool that combines Pylint, pyflakes, and pycodestyle for checking Python code against coding standards.
+
+# Check a single Python file for code style issues
+flake8 script.py
+
+# Recursively check all Python files in a directory
+flake8 path/to/directory/
+
+# Exclude specific files or directories from being checked
+flake8 --exclude=dir1,dir2,file.py
+
+# Check Python code and limit the maximum line length
+flake8 --max-line-length=100 script.py
+
+# Use a custom configuration file for linting settings
+flake8 --config=path/to/config-file script.py
+
+# Display only errors and warnings (suppress other output)
+flake8 --quiet script.py
+
+# Enable additional error codes, such as all E and W codes
+flake8 --select=E,W script.py
+
+# Ignore specific error codes, such as E123 and W504
+flake8 --ignore=E123,W504 script.py
+
+# Show statistics on the types of violations found
+flake8 --statistics script.py
+
+# Show detailed information about each error
+flake8 --format=html script.py
+
+# Output results to a file instead of the console
+flake8 script.py --output-file=report.txt

--- a/sheets/isort
+++ b/sheets/isort
@@ -1,0 +1,32 @@
+# isort
+# A Python utility to sort imports alphabetically and automatically separates them into sections.
+
+# Sort imports in a single file
+isort my_script.py
+
+# Sort imports in all Python files in the current directory recursively
+isort .
+
+# Sort imports and show the diff without making changes
+isort my_script.py --diff
+
+# Sort imports in place and print changes made to the console
+isort my_script.py --verbose
+
+# Sort imports and enforce a specific style, such as the black style
+isort my_script.py --profile black
+
+# Check if imports are sorted and return an error code if not
+isort my_script.py --check
+
+# Ignore specific files or directories when sorting imports
+isort . --skip some_directory --skip some_file.py
+
+# Use a custom configuration file for complex setups
+isort . --settings-path path/to/.isort.cfg
+
+# Sort imports for all files in the current git repository, respecting gitignore
+isort --git
+
+# Sort imports and filter by file extension (e.g., only .py files)
+isort . --ext py

--- a/sheets/mypy
+++ b/sheets/mypy
@@ -1,0 +1,35 @@
+# mypy
+# An optional static type checker for Python that aims to combine the benefits of dynamic and static typing.
+
+# Check the type annotations of a single Python file
+mypy file.py
+
+# Check the type annotations of all Python files in the current directory
+mypy .
+
+# Check the type annotations including files in subdirectories (recursively)
+mypy --recursive .
+
+# Specify a configuration file to use during the check
+mypy --config-file mypy.ini file.py
+
+# Ignore any errors encountered in missing imports
+mypy --ignore-missing-imports file.py
+
+# Show only error messages without warnings or notes
+mypy --error-only file.py
+
+# Enable strict optional checking
+mypy --strict file.py
+
+# Check Python files with a specific Python version
+mypy --python-version 3.8 file.py
+
+# Run mypy with incremental checking disabled (for a complete check)
+mypy --no-incremental file.py
+
+# Specify a custom cache directory
+mypy --cache-dir /path/to/cache file.py
+
+# Display detailed information about the types of all expressions
+mypy --show-error-codes --show-column-numbers file.py

--- a/sheets/pycodestyle
+++ b/sheets/pycodestyle
@@ -1,0 +1,29 @@
+# pycodestyle
+# A tool to check Python code against the PEP 8 style conventions.
+
+# Check a specific file for PEP 8 compliance
+pycodestyle file.py
+
+# Check all Python files in a directory for PEP 8 compliance
+pycodestyle directory/
+
+# Show specific error codes when checking files
+pycodestyle --select=E,W file.py
+
+# Exclude specific error codes from the check
+pycodestyle --ignore=E123,W503 file.py
+
+# Set the maximum allowed line length (default is 79)
+pycodestyle --max-line-length=100 file.py
+
+# Show how many occurrences of each error/warning type were found
+pycodestyle --statistics file.py
+
+# Show error count and lines where violations occur in a detailed table
+pycodestyle --show-source file.py
+
+# Enable verbose mode to get more information while running checks
+pycodestyle --verbose file.py
+
+# Check PEP 8 compliance but only show a report and nothing else
+pycodestyle --quiet file.py

--- a/sheets/pydocstyle
+++ b/sheets/pydocstyle
@@ -1,0 +1,29 @@
+# pydocstyle
+# A documentation style checker for Python docstrings, based on PEP 257.
+
+# Check all Python files in the current directory for PEP 257 violations
+pydocstyle .
+
+# Check a specific file for PEP 257 violations
+pydocstyle example.py
+
+# Check specific directories and/or files for PEP 257 violations
+pydocstyle src/ tests/
+
+# Show violations for a specific convention only (e.g., D100)
+pydocstyle --convention=pep257 --add-ignore=D100 .
+
+# Ignore specific error codes while checking
+pydocstyle --add-ignore=D100,D101 .
+
+# Run without checking for specified error codes (ignoring them)
+pydocstyle --add-select=D101,D102,D103 .
+
+# Use the configuration file to specify options
+pydocstyle --config=.pydocstyle.cfg
+
+# Display the version of pydocstyle
+pydocstyle --version
+
+# Show help text with available options for pydocstyle
+pydocstyle --help

--- a/sheets/pylama
+++ b/sheets/pylama
@@ -1,0 +1,35 @@
+# pylama
+# A code audit tool for Python and JavaScript to check code for errors and style issues.
+
+# Lint a single Python file using default settings
+pylama script.py
+
+# Lint all Python files in the current directory
+pylama .
+
+# Lint Python files in a specific directory
+pylama /path/to/directory
+
+# Lint files using a specific configuration file
+pylama --config pylama.ini
+
+# Lint files and include only specific error codes (e.g., E101, E203)
+pylama --ignore W --select=E101,E203 script.py
+
+# Lint files and ignore specific error codes (e.g., E501)
+pylama --ignore E501 script.py
+
+# Lint files and enable verbose output
+pylama -v script.py
+
+# Lint files and output results in JSON format
+pylama --format json script.py
+
+# Lint a combination of Python and JavaScript files
+pylama script.py script.js
+
+# Lint files with specified linters (e.g., pylint, flake8)
+pylama --linters=pylint,flake8 script.py
+
+# Perform linting while explicitly disabling a linter
+pylama --linters=+mypy,-pylint script.py

--- a/sheets/pylint
+++ b/sheets/pylint
@@ -1,0 +1,35 @@
+# pylint
+# A static code analyzer and linting tool for Python that looks for programming errors, helps enforce coding standards, and checks for code smells.
+
+# Run pylint on a specific Python file
+pylint my_script.py
+
+# Run pylint on a directory containing multiple Python files
+pylint my_project/
+
+# Run pylint with only specific message types enabled (e.g., convention, warning, error)
+pylint --enable=C,W,E my_script.py
+
+# Run pylint with specified message types disabled (e.g., information, refactoring)
+pylint --disable=R,I my_script.py
+
+# Run pylint and generate an output report in JSON format
+pylint --output-format=json my_script.py
+
+# Run pylint and output the results to a file
+pylint my_script.py > pylint_report.txt
+
+# Run pylint using a specific configuration file
+pylint --rcfile=pylintrc my_script.py
+
+# Run pylint and generate a report that includes only errors
+pylint --errors-only my_script.py
+
+# Display information about warnings individually with verbose output
+pylint --msg-template='{msg_id}:{line:3d},{column}: {obj}: {msg}' my_script.py
+
+# Run pylint with a maximum number of allowed messages reported
+pylint --max-line-length=100 my_script.py
+
+# Specify additional directories to add to the Python module search path
+pylint --init-hook='import sys; sys.path.append("additional_dir")' my_script.py

--- a/sheets/pylint-exit
+++ b/sheets/pylint-exit
@@ -1,0 +1,16 @@
+# pylint-exit
+# A tool to convert Pylint messages into exit codes for use in CI pipelines.
+
+# Use `pylint-exit` to convert Pylint messages into exit codes
+pylint-exit --error-exit-code=1 --warning-exit-code=2 --refactor-exit-code=3 --convention-exit-code=4 --usage-exit-code=5 --fatal-exit-code=6 pylint_output.txt
+
+# Simple usage to trigger a specific exit code for errors only
+pylint-exit --error-exit-code=1 pylint_output.txt
+
+# Setting custom exit codes for different message categories
+pylint-exit --error-exit-code=10 --warning-exit-code=20 --refactor-exit-code=30 pylint_output.txt
+
+# Using `pylint-exit` with a Pylint run and chaining commands; exit if there are errors
+pylint module_or_package | tee pylint_output.txt && pylint-exit --error-exit-code=1 pylint_output.txt
+
+# **Note**: In these examples, `pylint_output.txt` represents the file where you might have saved the output of a Pylint run if not directly chaining commands.

--- a/sheets/yapf
+++ b/sheets/yapf
@@ -1,0 +1,32 @@
+# yapf
+# Yet another Python formatter that reformats Python code to make it more readable.
+
+# Format a single Python file in place
+yapf -i <file_name.py>
+
+# Preview the formatting changes without altering the file
+yapf <file_name.py>
+
+# Format all Python files in a directory in place
+yapf -i -r <directory_name>
+
+# Preview formatting changes for all Python files in a directory
+yapf -r <directory_name>
+
+# Format a Python file using a specific style (e.g., pep8, google)
+yapf -i --style=<style_name> <file_name.py>
+
+# Preview changes using a specific style
+yapf --style=<style_name> <file_name.py>
+
+# Format a file and save the changes to another file
+yapf <file_name.py> > <output_file_name.py>
+
+# Run yapf with a custom configuration file
+yapf --style=<config_file_path> <file_name.py>
+
+# Show diff of what would be changed
+yapf --diff <file_name.py>
+
+# Display help message with all available options
+yapf --help

--- a/topics/python-code-formatting.json
+++ b/topics/python-code-formatting.json
@@ -1,0 +1,58 @@
+[
+  {
+    "command": "autoflake",
+    "description": "Removes unused imports and variables in Python code."
+  },
+  {
+    "command": "autopep8",
+    "description": "Automatically formats Python code to conform to the PEP 8 style guide."
+  },
+  {
+    "command": "bandit",
+    "description": "A tool designed to find security issues in Python code."
+  },
+  {
+    "command": "black",
+    "description": "The uncompromising code formatter for Python that reformats entire files in place."
+  },
+  {
+    "command": "flake8",
+    "description": "A wrapper tool that combines Pylint, pyflakes, and pycodestyle for checking Python code against coding standards."
+  },
+  {
+    "command": "isort",
+    "description": "A Python utility to sort imports alphabetically and automatically separates them into sections."
+  },
+  {
+    "command": "mypy",
+    "description": "An optional static type checker for Python that aims to combine the benefits of dynamic and static typing."
+  },
+  {
+    "command": "pycodestyle",
+    "description": "A tool to check Python code against the PEP 8 style conventions."
+  },
+  {
+    "command": "pydocstyle",
+    "description": "A documentation style checker for Python docstrings, based on PEP 257."
+  },
+  {
+    "command": "pylama",
+    "description": "A code audit tool for Python and JavaScript to check code for errors and style issues."
+  },
+  {
+    "command": "pylint",
+    "description": "A static code analyzer and linting tool for Python that looks for programming errors, helps enforce coding standards, and checks for code smells."
+  },
+  {
+    "command": "pylint-exit",
+    "description": "A tool to convert Pylint messages into exit codes for use in CI pipelines."
+  },
+  {
+    "command": "reorder-python-imports",
+    "description": "Automatically reorganizes and sorts Python imports, powered by isort with additional features."
+  },
+  {
+    "command": "yapf",
+    "description": "Yet another Python formatter that reformats Python code to make it more readable."
+  }
+]


### PR DESCRIPTION
| **Command**   | **Command Description**                                                          |
|---------------|----------------------------------------------------------------------------------|
| `autoflake`   | Removes unused imports and variables in Python code.                             |
| `autopep8`    | Automatically formats Python code to conform to the PEP 8 style guide.           |
| `bandit`      | A tool designed to find security issues in Python code.                          |
| `black`       | The uncompromising code formatter for Python that reformats entire files in place. |
| `flake8`      | A wrapper tool that combines Pylint, pyflakes, and pycodestyle for checking Python code against coding standards. |
| `isort`       | A Python utility to sort imports alphabetically and automatically separates them into sections. |
| `mypy`        | An optional static type checker for Python that aims to combine the benefits of dynamic and static typing. |
| `pycodestyle` | A tool to check Python code against the PEP 8 style conventions.                 |
| `pydocstyle`  | A documentation style checker for Python docstrings, based on PEP 257.           |
| `pylama`      | A code audit tool for Python and JavaScript to check code for errors and style issues. |
| `pylint`      | A static code analyzer and linting tool for Python that looks for programming errors, helps enforce coding standards, and checks for code smells. |
| `pylint-exit` | A tool to convert Pylint messages into exit codes for use in CI pipelines.       |
| `reorder-python-imports`| Automatically reorganizes and sorts Python imports, powered by isort with additional features. |
| `yapf`        | Yet another Python formatter that reformats Python code to make it more readable. |